### PR TITLE
BUMP: default ethdo version to support fulu

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Config options can be set as environment vars or defined in an .env file.
 | OPERATOR_ID                      | ""                    | Yes      | Your LIDO Operator ID (auto-detected for Stereum users)       |
 | SIGN_PERCENT                     | 10                    | No       | Percent of operators validators to sign exit messages for     |
 | VALIDATOR_EJECTOR_MESSAGE_FOLDER | ""                    | No       | Path to exit messages (auto-detected for Stereum users)       |
-| ETHDO_VERSION                    | "1.37.3"              | No       | Version of ethdo executable to use for signing                |
+| ETHDO_VERSION                    | "1.39.0"              | No       | Version of ethdo executable to use for signing                |
 
 > SIGN_PERCENT can be overwritten using the `--signpercent` argument
 
@@ -33,6 +33,7 @@ cd ~/exit-signer
 ```
 wget -O ./exitsigner https://github.com/RockLogicGmbH/lido-validator-exit-signer/releases/download/0.1.3/exitsigner-ubuntu-latest
 ```
+
 **Make sure to check the version if you copy paste the command above!**
 
 5. Give the exitsigner application execute permission

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ default_values = {
     "OPERATOR_ID": "",
     "SIGN_PERCENT": 10,
     "VALIDATOR_EJECTOR_MESSAGE_FOLDER": "",
-    "ETHDO_VERSION": "1.37.3",
+    "ETHDO_VERSION": "1.39.0",
 }
 
 # Retrieve config values from environment or use defaults


### PR DESCRIPTION
# Changes

## Implementation Details

Updated `ethdo` version in `main.py` and `README.md` to `1.39.0`.

---

# Post-Implementation Validation (If Needed)

## Validation Details

- Validation Date:
  05.03.2026

- Validation Performed By:
  David Szammer

Security Testing Performed:

- [ ] Yes
- [ ] No
- [ ] N/A
- [x] Manual Testing

## Validation Notes

Just updated the version numbers in source code.
Manually reviewed source of origin ethdo repository - looks good so far.

---

# Security Review

- [x] I confirm that I understand and have complied with all requirements outlined in the [Secure Development Guideline](https://rocklogic.sharepoint.com/sites/Intranet#secure-development-guideline).