### PR TITLE
CHORE: rollout sync-labels.yml

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,27 @@
+name: Sync labels
+
+on:
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  labels:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout shared .github repo
+        uses: actions/checkout@v4
+        with:
+          repository: RockLogicGmbH/.github
+          ref: main
+          sparse-checkout: .github/labels.yml
+
+      - name: Sync labels
+        uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yml
+          delete-other-labels: false
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR rolls out the sync-labels.yml workflow file.